### PR TITLE
Save/restore implementation + Process name data

### DIFF
--- a/src/Logitech/Artemis.Plugins.Wrappers.Logitech/Modules/LogitechWrapper/DataModels/LogitechWrapperDataModel.cs
+++ b/src/Logitech/Artemis.Plugins.Wrappers.Logitech/Modules/LogitechWrapper/DataModels/LogitechWrapperDataModel.cs
@@ -1,4 +1,5 @@
-﻿using Artemis.Core.Modules;
+﻿using System;
+using Artemis.Core.Modules;
 using SkiaSharp;
 
 namespace Artemis.Plugins.Wrappers.Logitech.Modules.DataModels
@@ -7,5 +8,6 @@ namespace Artemis.Plugins.Wrappers.Logitech.Modules.DataModels
     {
         public SKColor BackgroundColor { get; set; }
         public LogitechKeysDataModel Keys { get; set; } = new();
+        public string CurrentApplication { get; set; } = String.Empty;
     }
 }

--- a/src/Logitech/Artemis.Plugins.Wrappers.Logitech/Modules/LogitechWrapper/LogitechWrapperModule.cs
+++ b/src/Logitech/Artemis.Plugins.Wrappers.Logitech/Modules/LogitechWrapper/LogitechWrapperModule.cs
@@ -7,6 +7,7 @@ using Serilog;
 using SkiaSharp;
 using System;
 using System.Collections.Generic;
+using System.IO;
 
 namespace Artemis.Plugins.Wrappers.Logitech.Modules
 {
@@ -26,6 +27,7 @@ namespace Artemis.Plugins.Wrappers.Logitech.Modules
         public override void Enable()
         {
             _wrapperService.ColorsUpdated += WrapperServiceOnColorsUpdated;
+            _wrapperService.ClientConnected += WrapperServiceOnClientConnected;
             _wrapperService.ClientDisconnected += WrapperServiceOnClientDisconnected;
         }
 
@@ -53,8 +55,14 @@ namespace Artemis.Plugins.Wrappers.Logitech.Modules
             }
         }
 
+        private void WrapperServiceOnClientConnected(object sender, string e)
+        {
+            DataModel.CurrentApplication = Path.GetFileName(e);
+        }
+
         private void WrapperServiceOnClientDisconnected(object sender, EventArgs e)
         {
+            DataModel.CurrentApplication = string.Empty;
             DataModel.BackgroundColor = SKColor.Empty;
             DataModel.Keys.ClearDynamicChildren();
             _colorsCache.Clear();

--- a/src/Logitech/Artemis.Plugins.Wrappers.Logitech/Prerequisites/LogitechWrapperPrerequisite.cs
+++ b/src/Logitech/Artemis.Plugins.Wrappers.Logitech/Prerequisites/LogitechWrapperPrerequisite.cs
@@ -10,10 +10,10 @@ internal class LogitechWrapperPrerequisite : PluginPrerequisite
     private const string DLL_NAME = "LogitechLed.dll";
 
     private const string REGISTRY_PATH_64 =
-        "SOFTWARE\\Classes\\CLSID\\{a6519e67-7632-4375-afdf-caa889744403}\\ServerBinary";
+        @"SOFTWARE\Classes\CLSID\{a6519e67-7632-4375-afdf-caa889744403}\ServerBinary";
 
     private const string REGISTRY_PATH_32 =
-        "SOFTWARE\\Classes\\WOW6432Node\\CLSID\\{a6519e67-7632-4375-afdf-caa889744403}\\ServerBinary";
+        @"SOFTWARE\Classes\WOW6432Node\CLSID\{a6519e67-7632-4375-afdf-caa889744403}\ServerBinary";
 
     private readonly string _dllPath32;
     private readonly string _dllPath64;


### PR DESCRIPTION
Save/restore methods were needed for Mirrors's Edge Catalyst.


Process name can be used to activate/deactivate profiles