### PR TITLE
change Logitech pipe name number from decimal to hexadecimal

### DIFF
--- a/src/Logitech/Artemis.Plugins.Wrappers.Logitech/Services/LogitechPipeListenerService.cs
+++ b/src/Logitech/Artemis.Plugins.Wrappers.Logitech/Services/LogitechPipeListenerService.cs
@@ -39,7 +39,7 @@ namespace Artemis.Plugins.Wrappers.Logitech.Services
             _excluded = new();
 
             var id = WTSGetActiveConsoleSessionId();
-            var pipeName = $"LGS_LED_SDK-{id:00000000}";
+            var pipeName = "LGS_LED_SDK-" + id.ToString("x8");
             _pipeListener = new(pipeName);
             _pipeListener.ClientConnected += OnPipeListenerClientConnected;
             _pipeListener.ClientDisconnected += OnPipeListenerClientDisconnected;


### PR DESCRIPTION
Apparantly the SDK uses hexadecimal numbering for the pipe name. Learned today by having the session number 10